### PR TITLE
clean: re-remove BuddhaNexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ If you have something awesome to add, let us know. If not, why not make somethin
 
 ## external web
 
-- [BuddhaNexus](https://buddhanexus.net): use machine learning to analyze text relations.
 - [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net
 - [SC Light](https://sc.readingfaithfully.org/): a super-simple interface for finding a SuttaCentral text.
 - [Reading Faithfully](https://readingfaithfully.org/): reading guides and help with Suttas. Extra awesome: includes Pali/English epubs!


### PR DESCRIPTION
## Summary

Re-remove BuddhaNexus from the list

## Details

- it was previously removed in c9a31296b669747e29d039065c3e82cd4fb57c18
  - and was accidentally got added back in a merge conflict resolution in 6cbb34df719448299cd85471493092fd53a91f83
- it is also [no longer](https://github.com/BuddhaNexus) [maintained](https://github.com/BuddhaNexus/buddhanexus) and [the URL](https://buddhanexus.net/) appears to not load either

## Context

See https://github.com/suttacentral/awesome/pull/3#issuecomment-4613368631