### PR TITLE
feat: add SC now and SC ru

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ If you have something awesome to add, let us know. If not, why not make somethin
 
 ## external web
 
-- [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net.
+- [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net. Includes all root texts and English translations.
+  - [SuttaCentral.now](https://suttacentral.now/): Another fast and minimal alternative frontend for SuttaCentral.net. Includes all root texts and all translations.
+  - [SuttaCentral Redirect](https://github.com/benmneb/suttacentral-redirect): A simple browser extension to switch between `suttacentral.net` and `.now` or `.express` — with optional auto-redirect. Available on [Chrome](https://chromewebstore.google.com/detail/noaddajdfegpjfgpmbhcbahofgkceaan) and [Firefox](https://addons.mozilla.org/firefox/addon/suttacentral-redirect/).
 - [SC Light](https://sc.readingfaithfully.org/): a super-simple interface for finding a SuttaCentral text.
 - [Reading Faithfully](https://readingfaithfully.org/): reading guides and help with Suttas. Extra awesome: includes Pali/English epubs!
 - [A Sutta a Day](https://daily.readingfaithfully.org/): sign up with Reading Faithfully for Dhamma in your Inbox.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you have something awesome to add, let us know. If not, why not make somethin
 
 ## external web
 
+- [suttacentral.ru](https://suttacentral.ru/): Russian mirror of SuttaCentral.
 - [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net. Includes all root texts and English translations.
   - [SuttaCentral.now](https://suttacentral.now/): Another fast and minimal alternative frontend for SuttaCentral.net. Includes all root texts and all translations.
   - [SuttaCentral Redirect](https://github.com/benmneb/suttacentral-redirect): A simple browser extension to switch between `suttacentral.net` and `.now` or `.express` — with optional auto-redirect. Available on [Chrome](https://chromewebstore.google.com/detail/noaddajdfegpjfgpmbhcbahofgkceaan) and [Firefox](https://addons.mozilla.org/firefox/addon/suttacentral-redirect/).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you have something awesome to add, let us know. If not, why not make somethin
 
 ## external web
 
-- [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net
+- [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net.
 - [SC Light](https://sc.readingfaithfully.org/): a super-simple interface for finding a SuttaCentral text.
 - [Reading Faithfully](https://readingfaithfully.org/): reading guides and help with Suttas. Extra awesome: includes Pali/English epubs!
 - [A Sutta a Day](https://daily.readingfaithfully.org/): sign up with Reading Faithfully for Dhamma in your Inbox.
@@ -27,7 +27,7 @@ If you have something awesome to add, let us know. If not, why not make somethin
 - [Dharma Pearls](https://canon.dharmapearls.net/): Chinese translations of Agamas by Charles Patton, whose work also features on SC.
 - [Dhamma Charts](https://www.dhammacharts.org/suttapitaka-chart/): beautiful and interactive charts of the whole canon.
 - [Pali Wordle](https://labs.buddhistuniversity.net/wordle-pali/): play wordle—on Pali!
-- [Dhammaregen](https://dhammaregen.net): Dhammaregen ist eine Webseite zum Studium früher buddhistischer Texte, im Speziellen der Suttas (Lehrreden des Buddha und seiner frühen Schülerinnen und Schüler). 
+- [Dhammaregen](https://dhammaregen.net): Dhammaregen ist eine Webseite zum Studium früher buddhistischer Texte, im Speziellen der Suttas (Lehrreden des Buddha und seiner frühen Schülerinnen und Schüler).
 - [Studies in Early Buddhism](https://early-buddhism.com/): Researching the Early Buddhist Texts. Discussions, teachings, and analysis by Jay Forrest, using revised versions of SC's translations.
 - [Dhamma Gift](https://find.dhamma.gift/): an alternate search for SuttaCentral, focussing on Pali, Russian, and English.
 - 如是我聞 (thus have I heard) by Zetasoft. View, search, and bookmark text from SC and CBETA. Chinese text and Pali text Sutras and their translations into many languages are included. Easy to read and make notes.


### PR DESCRIPTION
## Summary

Add [suttacentral.now](https://suttacentral.now) and [suttacentral.ru](https://suttacentral.ru)

## Details

- add suttacentral.now as another alternative front-end that has all translations available ([GitHub](https://github.com/benmneb/suttacentral-ssr), [forum post](https://discourse.suttacentral.net/t/suttacentral-now/42316?u=agilgur5))
  - clarify that suttacentral.express only has English translations ([GitHub](https://github.com/benmneb/suttacentral-static), [forum post](https://discourse.suttacentral.net/t/suttacentral-express/41648?u=agilgur5))
    - Follow-up to #4  
- also add the [SuttaCentral Redirect](https://github.com/benmneb/suttacentral-redirect) browser extension for redirecting to `.now` or `.express` alternative front-ends

- add suttacentral.ru as a Russian mirror of suttacentral.net to help with [availability](https://discourse.suttacentral.net/t/russian-mirror-of-suttacentral/42409?u=agilgur5) due to Cloudflare blocks

<details><summary><h3>Misc</h3></summary>

- also use consistent end-of-line formatting, i.e. punctuation and no trailing whitespace

</details>

## Verification

See the rendered markdown [in the last commit](https://github.com/agilgur5/awesome-suttacentral/blob/5d026577dae9e1039565cc9df65c647d835392c7/README.md#external-web)

## Notes to Reviewers

I combined these commits into one PR as they would otherwise merge conflict with each other

