### PR TITLE
feat: add SC browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you have something awesome to add, let us know. If not, why not make somethin
 
 - [SuttaCentral.Express](https://suttacentral.express/): a fast and minimal alternative frontend for SuttaCentral.net
 - [SC Light](https://sc.readingfaithfully.org/): a super-simple interface for finding a SuttaCentral text.
+- [SuttaCentral Enhancement Extension](https://github.com/thesunshade/SuttaCentral-Enhancement-Extension): Browser extension with feature enhancements for SuttaCentral.net. Available on [Chrome](https://chromewebstore.google.com/detail/suttacentral-enhancement/lfkeephdohbmmbinhckfdeoajdbbkian), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/suttacentral-enhancements/), and [Edge](https://microsoftedge.microsoft.com/addons/detail/suttacentral-enhancement-/pcfibmblmflmdhdaaeojhldgcandgdob).
 - [Reading Faithfully](https://readingfaithfully.org/): reading guides and help with Suttas. Extra awesome: includes Pali/English epubs!
 - [A Sutta a Day](https://daily.readingfaithfully.org/): sign up with Reading Faithfully for Dhamma in your Inbox.
 - [Random Sutta](https://r.readingfaithfully.org/): get a random sutta.


### PR DESCRIPTION
## Summary

Add links to the SC browser extension

## Details

- add the [SuttaCentral Enhancement Extension](https://github.com/thesunshade/SuttaCentral-Enhancement-Extension) for unofficial features ([forum post](https://discourse.suttacentral.net/t/a-browser-extension-for-suttacentral/36074?u=agilgur5))

## Verification

See the rendered markdown [of the commit](https://github.com/agilgur5/awesome-suttacentral/blob/1f423d33acca933771e2d571e25d2c34f99891e4/README.md#external-web)